### PR TITLE
feat: Implement OCToken NFT Open Collaborator Award mechanism (Fixes #53)

### DIFF
--- a/models/Award.ts
+++ b/models/Award.ts
@@ -10,7 +10,10 @@ export type Award = Record<
   | 'reason'
   | 'nominator'
   | 'createdAt'
-  | 'votes',
+  | 'votes'
+  | 'walletAddress'
+  | 'transactionHash'
+  | 'tokenId',
   TableCellValue
 >;
 

--- a/pages/api/Lark/award/issue.ts
+++ b/pages/api/Lark/award/issue.ts
@@ -20,9 +20,31 @@ router.post('/issue', safeAPI, verifyJWT, async (context: Context) => {
     context.throw(400, 'walletAddress must be a valid Ethereum address');
   }
 
-  // Issue OCToken NFT logic
-  const transactionHash = `0x${Math.random().toString(16).slice(2)}`;
-  const tokenId = Math.floor(Math.random() * 10000).toString();
+  let transactionHash: string;
+  let tokenId: string;
+
+  try {
+    const mintApiUrl = process.env.NFT_MINT_API || 'https://api.octoken.org/mint';
+    const response = await fetch(mintApiUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ walletAddress, recordId }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`NFT issuance failed with status ${response.status}`);
+    }
+
+    const data = await response.json();
+    transactionHash = data.transactionHash;
+    tokenId = data.tokenId;
+
+    if (!transactionHash || !tokenId) {
+      throw new Error('Invalid response from minting service');
+    }
+  } catch (error) {
+    return context.throw(502, (error as Error).message || 'NFT issuance failed');
+  }
 
   const awardModel = new AwardModel();
   await awardModel.updateOne(

--- a/pages/api/Lark/award/issue.ts
+++ b/pages/api/Lark/award/issue.ts
@@ -1,0 +1,31 @@
+import { Context } from 'koa';
+import { createKoaRouter, withKoaRouter } from 'next-ssr-middleware';
+import { AwardModel } from '../../../../models/Award';
+import { safeAPI, verifyJWT } from '../../core';
+
+export const config = { api: { bodyParser: true } };
+
+const router = createKoaRouter(import.meta.url);
+
+router.post('/issue', safeAPI, verifyJWT, async (context: Context) => {
+  const { recordId, walletAddress } = (context.request as any).body;
+
+  if (!recordId || !walletAddress) {
+    context.throw(400, 'recordId and walletAddress are required');
+  }
+
+  // Issue OCToken NFT logic
+  const transactionHash = `0x${Math.random().toString(16).slice(2)}`;
+  const tokenId = Math.floor(Math.random() * 10000).toString();
+
+  const awardModel = new AwardModel();
+  await awardModel.updateOne({
+    transactionHash,
+    tokenId,
+    walletAddress
+  }, recordId);
+
+  context.body = { success: true, transactionHash, tokenId };
+});
+
+export default withKoaRouter(router);

--- a/pages/api/Lark/award/issue.ts
+++ b/pages/api/Lark/award/issue.ts
@@ -9,6 +9,30 @@ const router = createKoaRouter(import.meta.url);
 
 const EthereumAddressPattern = /^0x[a-fA-F0-9]{40}$/;
 
+const getUserIds = (field: any): string[] => {
+  if (!field) return [];
+  if (Array.isArray(field)) {
+    return field.map(u => (typeof u === 'object' && u ? u.id : String(u))).filter(Boolean);
+  }
+  if (typeof field === 'object' && field) {
+    return [field.id].filter(Boolean);
+  }
+  return [String(field)];
+};
+
+const getUserNames = (field: any): string[] => {
+  if (!field) return [];
+  if (Array.isArray(field)) {
+    return field
+      .map(u => (typeof u === 'object' && u ? u.name || u.id : String(u)))
+      .filter(Boolean);
+  }
+  if (typeof field === 'object' && field) {
+    return [field.name || field.id].filter(Boolean);
+  }
+  return [String(field)];
+};
+
 router.post('/issue', safeAPI, verifyJWT, async (context: Context) => {
   const { recordId, walletAddress } = (context.request as any).body;
 
@@ -33,16 +57,32 @@ router.post('/issue', safeAPI, verifyJWT, async (context: Context) => {
     context.throw(401, 'Unauthorized');
   }
 
+  const nominators = getUserIds(award.nominator);
+  const nomineeNames = getUserIds(award.nomineeName);
+  const nominatorNames = getUserNames(award.nominator);
+  const nomineeUserNames = getUserNames(award.nomineeName);
+  const currentUserIdStr = String(currentUser.id);
+
   if (
-    currentUser.name !== 'Robot' &&
-    currentUser.name !== award.nominator &&
-    currentUser.name !== award.nomineeName
+    currentUser.id !== 0 && // Robot bypass by stable ID 0
+    !nominators.includes(currentUserIdStr) &&
+    !nomineeNames.includes(currentUserIdStr) &&
+    !nominatorNames.includes(currentUser.name) &&
+    !nomineeUserNames.includes(currentUser.name)
   ) {
     context.throw(403, 'You do not have permission to issue this award');
   }
 
-  // 2. Idempotency Check
+  // 2. Concurrency Lock check
+  if (award.transactionHash === 'ISSUING') {
+    context.throw(409, 'An NFT issuance request is already in progress for this award');
+  }
+
+  // 3. Idempotency and Wallet binding check
   if (award.transactionHash && award.tokenId) {
+    if (award.walletAddress && award.walletAddress !== walletAddress) {
+      context.throw(409, 'This award has already been issued to a different wallet address');
+    }
     context.body = {
       success: true,
       transactionHash: award.transactionHash as string,
@@ -50,6 +90,15 @@ router.post('/issue', safeAPI, verifyJWT, async (context: Context) => {
     };
     return;
   }
+
+  // 4. Acquire lock
+  await awardModel.updateOne(
+    {
+      transactionHash: 'ISSUING',
+      walletAddress,
+    },
+    recordId,
+  );
 
   let transactionHash: string;
   let tokenId: string;
@@ -79,6 +128,16 @@ router.post('/issue', safeAPI, verifyJWT, async (context: Context) => {
       throw new Error('Invalid response from minting service');
     }
   } catch (error) {
+    // Revert the concurrency lock on failure
+    await awardModel
+      .updateOne(
+        {
+          transactionHash: '',
+        },
+        recordId,
+      )
+      .catch(e => console.error('Failed to revert transaction lock:', e));
+
     const msg =
       (error as Error).name === 'AbortError'
         ? 'NFT issuance request timed out'
@@ -86,6 +145,7 @@ router.post('/issue', safeAPI, verifyJWT, async (context: Context) => {
     return context.throw(502, msg);
   }
 
+  // 5. Finalize the record with actual transaction details
   await awardModel.updateOne(
     {
       transactionHash,

--- a/pages/api/Lark/award/issue.ts
+++ b/pages/api/Lark/award/issue.ts
@@ -7,11 +7,17 @@ export const config = { api: { bodyParser: true } };
 
 const router = createKoaRouter(import.meta.url);
 
+const EthereumAddressPattern = /^0x[a-fA-F0-9]{40}$/;
+
 router.post('/issue', safeAPI, verifyJWT, async (context: Context) => {
   const { recordId, walletAddress } = (context.request as any).body;
 
   if (!recordId || !walletAddress) {
     context.throw(400, 'recordId and walletAddress are required');
+  }
+
+  if (typeof walletAddress !== 'string' || !EthereumAddressPattern.test(walletAddress)) {
+    context.throw(400, 'walletAddress must be a valid Ethereum address');
   }
 
   // Issue OCToken NFT logic

--- a/pages/api/Lark/award/issue.ts
+++ b/pages/api/Lark/award/issue.ts
@@ -20,16 +20,52 @@ router.post('/issue', safeAPI, verifyJWT, async (context: Context) => {
     context.throw(400, 'walletAddress must be a valid Ethereum address');
   }
 
+  // 1. Fetch award and check authorization
+  const awardModel = new AwardModel();
+  const award = await awardModel.getOne(recordId);
+
+  if (!award) {
+    context.throw(404, 'Award record not found');
+  }
+
+  const currentUser = (context.state as any).user;
+  if (!currentUser) {
+    context.throw(401, 'Unauthorized');
+  }
+
+  if (
+    currentUser.name !== 'Robot' &&
+    currentUser.name !== award.nominator &&
+    currentUser.name !== award.nomineeName
+  ) {
+    context.throw(403, 'You do not have permission to issue this award');
+  }
+
+  // 2. Idempotency Check
+  if (award.transactionHash && award.tokenId) {
+    context.body = {
+      success: true,
+      transactionHash: award.transactionHash as string,
+      tokenId: award.tokenId as string,
+    };
+    return;
+  }
+
   let transactionHash: string;
   let tokenId: string;
 
   try {
     const mintApiUrl = process.env.NFT_MINT_API || 'https://api.octoken.org/mint';
+    const timeoutVal = parseInt(process.env.NFT_MINT_TIMEOUT || '10000', 10);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutVal);
+
     const response = await fetch(mintApiUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ walletAddress, recordId }),
-    });
+      signal: controller.signal,
+    }).finally(() => clearTimeout(timeout));
 
     if (!response.ok) {
       throw new Error(`NFT issuance failed with status ${response.status}`);
@@ -43,10 +79,13 @@ router.post('/issue', safeAPI, verifyJWT, async (context: Context) => {
       throw new Error('Invalid response from minting service');
     }
   } catch (error) {
-    return context.throw(502, (error as Error).message || 'NFT issuance failed');
+    const msg =
+      (error as Error).name === 'AbortError'
+        ? 'NFT issuance request timed out'
+        : (error as Error).message || 'NFT issuance failed';
+    return context.throw(502, msg);
   }
 
-  const awardModel = new AwardModel();
   await awardModel.updateOne(
     {
       transactionHash,

--- a/pages/api/Lark/award/issue.ts
+++ b/pages/api/Lark/award/issue.ts
@@ -19,11 +19,14 @@ router.post('/issue', safeAPI, verifyJWT, async (context: Context) => {
   const tokenId = Math.floor(Math.random() * 10000).toString();
 
   const awardModel = new AwardModel();
-  await awardModel.updateOne({
-    transactionHash,
-    tokenId,
-    walletAddress
-  }, recordId);
+  await awardModel.updateOne(
+    {
+      transactionHash,
+      tokenId,
+      walletAddress,
+    },
+    recordId,
+  );
 
   context.body = { success: true, transactionHash, tokenId };
 });


### PR DESCRIPTION
[![PR-76](https://badgen.net/badge/GitHub.dev/PR-76/blue?icon=visualstudio)](https://github.dev/Open-Source-Bazaar/Open-Source-Bazaar.github.io/pull/76) [![PR-76](https://badgen.net/badge/GitHub%20codespaces/PR-76/black?icon=github)](https://codespaces.new/Open-Source-Bazaar/Open-Source-Bazaar.github.io/pull/76) [![PR-76](https://badgen.net/badge/GitPod.io/PR-76/orange?icon=git)](https://gitpod.io/?autostart=true#https://github.com/Open-Source-Bazaar/Open-Source-Bazaar.github.io/pull/76) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Open-Source-Bazaar&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Closes #53 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 新功能
* **奖励发放接口**：新增奖励“发放/入库”API端点，支持参数与钱包地址校验、权限与状态检查；不存在/未授权/违规操作返回对应错误；已存在交易信息则支持幂等直接返回。
* **外部铸造服务**：对外部 NFT 铸造请求增加超时控制；对超时、响应异常与数据不完整按统一规则返回错误，成功后返回交易哈希与代币ID。

## 数据模型变更
* **Award 类型补强**：完善 `Award` 关键字段（如投票数、钱包地址、交易哈希、代币ID）字段枚举与类型约束。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### 💳 Payout Details
Please send the bounty rewards to the following payout methods:
* **PayPal**: https://paypal.me/sureshc26
