### PR TITLE
chore: add PR contributor trust checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,9 @@ Checklist（清单）:
 - [ ] Labels
 - [ ] Assignees
 - [ ] Reviewers
+- [ ] I confirmed I am not a bot and manually reviewed this change.
+- [ ] I listed tests, manual verification, or reproduction steps.
+- [ ] I reviewed recent commits on this branch for noisy/irrelevant churn.
 
 <!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.（如果 pull request 关闭一个 GitHub issue，请用 GitHub issue 编号替换下面的 XXXXX）-->
 

--- a/.github/workflows/pr-contributor-trust.yml
+++ b/.github/workflows/pr-contributor-trust.yml
@@ -1,0 +1,45 @@
+name: PR Contributor Trust
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  trust-check:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+      contents: read
+    steps:
+      - name: Flag suspicious bot patterns
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pull = context.payload.pull_request;
+            const actor = (pull.user && pull.user.login) || '';
+            const login = actor.toLowerCase();
+            const title = (pull.title || '').toLowerCase();
+            const body = (pull.body || '').toLowerCase();
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = pull.number;
+
+            const suspiciousActor = login.includes('[bot]') || login.includes('dependabot') || login.includes('renovate');
+            const suspiciousContent = title.includes('auto') || title.includes('generated') || body.includes('i am an ai') || body.includes('generated with');
+            const missingChecklist = !body.includes('- [x]') && body.length < 80;
+
+            if (suspiciousActor || suspiciousContent || missingChecklist) {
+              const reason = `PR trust check: suspicious contributor profile or incomplete manual verification in PR description.\n\nDetected by PR Contributor Trust: actor=${actor}, title=${pull.title || '(none)'}, missing checklist=${missingChecklist}.`;
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body: reason
+              });
+
+              core.setFailed('PR needs manual human review before trust score is accepted.');
+            }


### PR DESCRIPTION
[![PR-104](https://badgen.net/badge/GitHub.dev/PR-104/blue?icon=visualstudio)](https://github.dev/Open-Source-Bazaar/Open-Source-Bazaar.github.io/pull/104) [![PR-104](https://badgen.net/badge/GitHub%20codespaces/PR-104/black?icon=github)](https://codespaces.new/Open-Source-Bazaar/Open-Source-Bazaar.github.io/pull/104) [![PR-104](https://badgen.net/badge/GitPod.io/PR-104/orange?icon=git)](https://gitpod.io/?autostart=true#https://github.com/Open-Source-Bazaar/Open-Source-Bazaar.github.io/pull/104) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Open-Source-Bazaar&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Implemented a lightweight contributor-trust hardening for `#89` with two direct changes:
- Added PR checklist items that force manual trust verification and test reporting.
- Added a `PR Contributor Trust` workflow that flags suspicious automated/bot-like submissions and comments for manual review.

Completed the task. If this saved you time, tips/bounties are welcome here:
SOL: 69cT26eTDKnqq3wfmDAau7mVBrN8vJTnVbMaSU4DVfxB | Base USDC: 0x4f0b7ac041FCEE7f3e4b3B0E22DBfC3bb2bE0CE7 | ETH: 0x4f0b7ac041FCEE7f3e4b3B0E22DBfC3bb2bE0CE7 | Polygon: 0x4f0b7ac041FCEE7f3e4b3B0E22DBfC3bb2bE0CE7 | TRON: TJX27Jy21rGeUqP5ePYFVM3gFL2ZZGyqHL | XMR: 48p5DD5DXtrWwbiuDTGKXb3oacJ6g6jnxXswUZ1Tggo3XBc6mj34Nna87dAbZSCnGufQSCSen3BEdBZycBy3dDQdKgVxJCj 